### PR TITLE
Update SDKMessageHandler to allow multiple non-contract signers

### DIFF
--- a/x/wasm/keeper/handler_plugin.go
+++ b/x/wasm/keeper/handler_plugin.go
@@ -86,10 +86,8 @@ func (h SDKMessageHandler) handleSdkMessage(ctx sdk.Context, contractAddr sdk.Ad
 		return nil, err
 	}
 	// make sure this account can send it
-	for _, acct := range msg.GetSigners() {
-		if !acct.Equals(contractAddr) {
-			return nil, sdkerrors.Wrap(sdkerrors.ErrUnauthorized, "contract doesn't have permission")
-		}
+	if len(msg.GetSigners()) == 0 || !msg.GetSigners()[0].Equals(contractAddr) {
+		return nil, sdkerrors.Wrap(sdkerrors.ErrUnauthorized, "contract doesn't have permission")
 	}
 
 	// find the handler and execute it

--- a/x/wasm/keeper/handler_plugin_test.go
+++ b/x/wasm/keeper/handler_plugin_test.go
@@ -135,6 +135,17 @@ func TestSDKMessageHandlerDispatch(t *testing.T) {
 			},
 			expMsgDispatched: 1,
 		},
+		"handle multiple signers": {
+			srcRoute: capturingMessageRouter,
+			srcEncoder: func(sender sdk.AccAddress, msg json.RawMessage) ([]sdk.Msg, error) {
+				myMsg := MockMessage{
+					validateError: nil,
+					signers:       []sdk.AccAddress{myContractAddr, sdk.MustAccAddressFromBech32(RandomBech32AccountAddress(t))},
+				}
+				return []sdk.Msg{&myMsg}, nil
+			},
+			expMsgDispatched: 1,
+		},
 		"multiple output msgs": {
 			srcRoute: capturingMessageRouter,
 			srcEncoder: func(sender sdk.AccAddress, msg json.RawMessage) ([]sdk.Msg, error) {
@@ -421,4 +432,29 @@ func TestBurnCoinMessageHandlerIntegration(t *testing.T) {
 
 	// test cases:
 	// not enough money to burn
+}
+
+type MockMessage struct {
+	validateError error
+	signers       []sdk.AccAddress
+}
+
+func (msg MockMessage) GetSigners() []sdk.AccAddress {
+	return msg.signers
+}
+
+func (msg MockMessage) ValidateBasic() error {
+	return msg.validateError
+}
+
+func (msg MockMessage) Reset() {
+
+}
+
+func (msg MockMessage) String() string {
+	return ""
+}
+
+func (msg MockMessage) ProtoMessage() {
+
 }

--- a/x/wasm/keeper/msg_server.go
+++ b/x/wasm/keeper/msg_server.go
@@ -112,7 +112,6 @@ func (m msgServer) InstantiateContract2(goCtx context.Context, msg *types.MsgIns
 	policy := m.selectAuthorizationPolicy(msg.Sender)
 	addrGenerator := PredicableAddressGenerator(senderAddr, msg.Salt, msg.Msg, msg.FixMsg)
 	contractAddr, data, err := m.keeper.instantiate(ctx, msg.CodeID, senderAddr, adminAddr, msg.Msg, msg.Label, msg.Funds, addrGenerator, policy)
-
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR is in regards to github/provenance-io/provenance#1280. It updates the SDKMessageHandler to only enforce that the first signer must be the contract address.