### PR TITLE
Add missing pagination flags to list-contracts-by-creator.

### DIFF
--- a/x/wasm/client/cli/query.go
+++ b/x/wasm/client/cli/query.go
@@ -139,7 +139,7 @@ func GetCmdListCode() *cobra.Command {
 		},
 	}
 	flags.AddQueryFlagsToCmd(cmd)
-	flags.AddPaginationFlagsToCmd(cmd, "list codes")
+	flags.AddPaginationFlagsToCmd(cmd, "codes")
 	return cmd
 }
 
@@ -184,7 +184,7 @@ func GetCmdListContractByCode() *cobra.Command {
 		},
 	}
 	flags.AddQueryFlagsToCmd(cmd)
-	flags.AddPaginationFlagsToCmd(cmd, "list contracts by code")
+	flags.AddPaginationFlagsToCmd(cmd, "contracts by code")
 	return cmd
 }
 
@@ -525,7 +525,7 @@ func GetCmdListPinnedCode() *cobra.Command {
 		},
 	}
 	flags.AddQueryFlagsToCmd(cmd)
-	flags.AddPaginationFlagsToCmd(cmd, "list codes")
+	flags.AddPaginationFlagsToCmd(cmd, "pinned code ids")
 	return cmd
 }
 
@@ -565,6 +565,7 @@ func GetCmdListContractsByCreator() *cobra.Command {
 		},
 	}
 	flags.AddQueryFlagsToCmd(cmd)
+	flags.AddPaginationFlagsToCmd(cmd, "contracts by creator")
 	return cmd
 }
 


### PR DESCRIPTION
Related: https://github.com/provenance-io/provenance/issues/1428

The `list-contracts-by-creator` query command was trying to read pagination flags but didn't add them to the command, so they were causing an error and the command was unusable.

This fixes that.

It also tweaks the `query` strings provided to `AddPaginationFlagsToCmd` for a few commands so that the flag descriptions read a bit better.

E.g. old: `pagination page-key of list contracts by code to query for`, new: `pagination page-key of contracts by code to query for`.