### PR TITLE
Bump wasmvm to v1.2.6 (from 1.2.4) and mark v0.30.0-pio-6 in the changelog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## [Unreleased](https://github.com/provenance-io/wasmd/tree/main-pio)
+## [v0.30.0-pio-5](https://github.com/provenance-io/wasmd/releases/tag/v0.30.0-pio-5) (2023-06-09)
 
-- Upgrade wasmvm to v1.2.4 [/#80](https://github.com/provenance-io/wasmd/pull/80)
+- Upgrade wasmvm to v1.2.4 [#80](https://github.com/provenance-io/wasmd/pull/80)
 
-[Full Changelog](https://github.com/CosmWasm/wasmd/compare/v0.30.0...HEAD)
+[Diff From v0.30.0](https://github.com/provenance-io/wasmd/compare/v0.30.0...v0.30.0-pio-5)
+[Diff From v0.30.0-pio-3](https://github.com/provenance-io/wasmd/compare/v0.30.0-pio-3...v0.30.0-pio-5)
 
 ## [v0.30.0-pio-3](https://github.com/provenance-io/wasmd/tree/notional-labs-46.7-pio-release) (2023-04-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v0.30.0-pio-6](https://github.com/provenance-io/wasmd/releases/tag/v0.30.0-pio-6) (2023-01-10)
+
+- Upgrade wasmvm to v1.2.6 [#1799](https://github.com/provenance-io/provenance/issues/1799)
+
+[Diff From v0.30.0](https://github.com/provenance-io/wasmd/compare/v0.30.0...v0.30.0-pio-6)
+[Diff From v0.30.0-pio-5](https://github.com/provenance-io/wasmd/compare/v0.30.0-pio-5...v0.30.0-pio-6)
+
 ## [v0.30.0-pio-5](https://github.com/provenance-io/wasmd/releases/tag/v0.30.0-pio-5) (2023-06-09)
 
 - Upgrade wasmvm to v1.2.4 [#80](https://github.com/provenance-io/wasmd/pull/80)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	cosmossdk.io/errors v1.0.0-beta.7
 	cosmossdk.io/math v1.0.0-beta.3
-	github.com/CosmWasm/wasmvm v1.2.4
+	github.com/CosmWasm/wasmvm v1.2.6
 	github.com/cosmos/cosmos-proto v1.0.0-alpha8
 	github.com/cosmos/cosmos-sdk v0.46.7
 	github.com/cosmos/gogoproto v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d h1:nalkkPQcITbvhmL4+C4cKA87NW0tfm3Kl9VXRoPywFg=
 github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
-github.com/CosmWasm/wasmvm v1.2.4 h1:6OfeZuEcEH/9iqwrg2pkeVtDCkMoj9U6PpKtcrCyVrQ=
-github.com/CosmWasm/wasmvm v1.2.4/go.mod h1:vW/E3h8j9xBQs9bCoijDuawKo9kCtxOaS8N8J7KFtkc=
+github.com/CosmWasm/wasmvm v1.2.6 h1:QmOaiJUyeh8+pPCjJBTgWrbi/hCzCuWewduDO85Pcpc=
+github.com/CosmWasm/wasmvm v1.2.6/go.mod h1:KO0zfQgCsQ6urWL1MYLlGqRgr7R4an6jo+LWRZjfD4c=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.5.0/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=


### PR DESCRIPTION
This bumps `github.com/CosmWasm/wasmvm` to v1.2.6 (from v1.2.4) to address a security concern.

This also marks v0.30.0-pio-6 in the changelog, which will be created after this PR is merged to `main-pio`.

Related Issue: https://github.com/provenance-io/provenance/issues/1799